### PR TITLE
Update Python version to 3.13.5

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.12"
+    python: "3.13.5"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
## Description

To merge #308 the [minimum Python version needs to be bumped](https://app.readthedocs.org/projects/mautic-developer/builds/31618183/). This PR does that. If the build passes, should be good to merge.